### PR TITLE
Update contributor-form.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/contributor-form.yml
+++ b/.github/ISSUE_TEMPLATE/contributor-form.yml
@@ -44,6 +44,7 @@ body:
         - Developing
         - Skilled
         - Adept
+        - N/A Theoretical content
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
Updated the contributor form to include 'N/A Theoretical content' as an alternative to the levels.